### PR TITLE
Add version number to footer in the frontend

### DIFF
--- a/iot-frontend/src/components/Footer.tsx
+++ b/iot-frontend/src/components/Footer.tsx
@@ -10,6 +10,10 @@ const Footer = () => {
           Copyright © Adroit {establishedYear} - {currentYear}. All rights reserved.
         </p>
       </div>
+
+      <div className="container mx-auto flex items-center justify-center">
+        <p className="text-sm text-center">v0.0.1</p>
+      </div>
     </footer>
   )
 }


### PR DESCRIPTION
We use Semantic Version Naming Convention

It uses a three-part version number in the format MAJOR.MINOR.PATCH, where:

Major Versions (X.0.0):
```
1.0.0: Initial release of the headless frontend with basic features.
2.0.0: Major update introducing significant changes such as a revamped UI, new major features

```

Minor Versions (0.Y.0):
```
1.1.0: Minor update adding new features or enhancements without breaking existing functionality.
1.2.0: Another minor update introducing additional features or improvements.
```

Patch Versions (0.0.Z):
```
1.0.1: Patch release addressing bugs or security vulnerabilities without adding new features.
1.0.2: Another patch release fixing additional bugs or minor issues.
```